### PR TITLE
Migrate to null safety dart 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.0] - 2021-03-08
+* Version 1.1.0 released.
+* Migrating to null-safety for dart 2.12
+
 ## [1.0.0] - 2019-07-09
 * Version 1.0.0 released.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,15 @@
 name: area
 description: Compute an area (in square meters) of a GeoJSON polygon or multipolygon
-version: 1.0.0
+version: 1.1.0
 author: Ikar Pohorský <ikarus.cz@gmail.com>
 homepage: https://github.com/porn/area
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  flutter:
+      sdk: flutter
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
Migrate to dart null safety.
This is to align with new null safety introduced in dart 2.12.